### PR TITLE
Updated L8 Aerosol dict. Corrected extract routine

### DIFF
--- a/Scripts/extract_bands.py
+++ b/Scripts/extract_bands.py
@@ -18,11 +18,19 @@ Version:        2.0
 Changelog
 1.0     15 May 2017     DNE in this release.
 2.0     20 Jun 2017     Original development.
+
+Modified July 2018
+Saeed Arab
+sarab@contractor.usgs.gov
+
+Changelog:
+Corrected the extract routine for 2-bit attributes
 """
 import sys
 import os
 import arcpy
 import lookup_dict
+from copy import deepcopy
 
 
 def extract_bits_from_band(raster_in, sensor, band, output_bands, basename,
@@ -67,9 +75,12 @@ def extract_bits_from_band(raster_in, sensor, band, output_bands, basename,
             return str_out
 
         # use conditional function to make binary raster
-        out = arcpy.sa.Con(in_raster, 1, 0, build_con_statement(out_values))
+        if len(build_con_statement(out_values)) == 0:  # Solution to Extracting non-existing pixels issue
+            out = arcpy.sa.Con(in_raster, 0, 1, build_con_statement(out_values))
+        else:
+            out = arcpy.sa.Con(in_raster, 1, 0, build_con_statement(out_values))
 
-        # set pixel depth to 8-bit unsigned and save to file
+            # set pixel depth to 8-bit unsigned and save to file
         arcpy.CopyRaster_management(out, out_raster,
                                     pixel_type="8_BIT_UNSIGNED")
 
@@ -127,7 +138,26 @@ def extract_bits_from_band(raster_in, sensor, band, output_bands, basename,
         bit_bool = []
         for v in unique_vals:
             if len(bit_value) == 1:  # single bit
-                bit_bool.append(v & 1 << bit_value[0] > 0)
+                #Check if the bit value exist in other dictionary elements
+                temp_bit_flags = deepcopy(bit_flags[band][sensor])
+                del temp_bit_flags[bv]
+                two_bit_elem = bit_value[0] in [p for q in temp_bit_flags.values() for p in q]
+                if two_bit_elem:
+                    for flags, value in bit_flags[band][sensor].iteritems():
+                        if value == [bit_value[0]-1,bit_value[0]]:
+                            #print flags
+                            if v & 1 << (bit_value[0]-1) > 0: # Check the neighbour bit
+                                pass
+                            else:
+                                bit_bool.append(v & 1 << bit_value[0] > 0)
+                        elif value == [bit_value[0],bit_value[0]+1]:
+                            #print flags
+                            if v & 1 << (bit_value[0]+1) > 0: # Check the neighbour bit
+                                pass
+                            else:
+                                bit_bool.append(v & 1 << bit_value[0] > 0)
+                else:
+                    bit_bool.append(v & 1 << bit_value[0] > 0)
 
             elif len(bit_value) > 1:  # 2+ bits
                 bits = []

--- a/Scripts/extract_bands.py
+++ b/Scripts/extract_bands.py
@@ -75,12 +75,13 @@ def extract_bits_from_band(raster_in, sensor, band, output_bands, basename,
             return str_out
 
         # use conditional function to make binary raster
-        if len(build_con_statement(out_values)) == 0:  # Solution to Extracting non-existing pixels issue
-            out = arcpy.sa.Con(in_raster, 0, 1, build_con_statement(out_values))
+        if len(build_con_statement(out_values)) == 0:
+            # if out_values is empty, set all pixels to zero
+            out = arcpy.sa.Con(in_raster, 0)
         else:
             out = arcpy.sa.Con(in_raster, 1, 0, build_con_statement(out_values))
 
-            # set pixel depth to 8-bit unsigned and save to file
+        # set pixel depth to 8-bit unsigned and save to file
         arcpy.CopyRaster_management(out, out_raster,
                                     pixel_type="8_BIT_UNSIGNED")
 
@@ -138,20 +139,22 @@ def extract_bits_from_band(raster_in, sensor, band, output_bands, basename,
         bit_bool = []
         for v in unique_vals:
             if len(bit_value) == 1:  # single bit
-                #Check if the bit value exist in other dictionary elements
+                # copy the dictionary and remove the desired single bit element
                 temp_bit_flags = deepcopy(bit_flags[band][sensor])
                 del temp_bit_flags[bv]
+                # search the rest of dictionary and see if the desired bit exists in other elements (2-bit attribute)
                 two_bit_elem = bit_value[0] in [p for q in temp_bit_flags.values() for p in q]
                 if two_bit_elem:
+                    # if the bit exist in a 2-bit element check the status of the adjacent bit
                     for flags, value in bit_flags[band][sensor].iteritems():
+                        # if previous bit is 1 then pass
                         if value == [bit_value[0]-1,bit_value[0]]:
-                            #print flags
                             if v & 1 << (bit_value[0]-1) > 0: # Check the neighbour bit
                                 pass
                             else:
                                 bit_bool.append(v & 1 << bit_value[0] > 0)
+                        # if next bit is 1 then pass
                         elif value == [bit_value[0],bit_value[0]+1]:
-                            #print flags
                             if v & 1 << (bit_value[0]+1) > 0: # Check the neighbour bit
                                 pass
                             else:

--- a/Scripts/lookup_dict.py
+++ b/Scripts/lookup_dict.py
@@ -20,6 +20,14 @@ Changelog
                         ArcGIS 10.4.1.
 1.1     09 Aug 2017     Update to handle any L8 pixel_qa terrain occlusion.
 1.2     21 Aug 2017     Removed lookup table, added bit flags.
+
+Modified July 2018
+Saeed Arab
+sarab@contractor.usgs.gov
+
+Changelog:
+Updated L8 sr_aerosol dict contents with regards to the LaSRC updates.
+Added "Medium Cirrus Confidence" for pixel_qa of L8
 """
 bit_flags = {
     "pixel_qa": {
@@ -45,6 +53,7 @@ bit_flags = {
             "Medium Cloud Confidence": [7],
             "High Cloud Confidence": [6, 7],
             "Low Cirrus Confidence": [8],
+            "Medium Cirrus Confidence": [9],
             "High Cirrus Confidence": [8, 9],
             "Terrain Occlusion": [10]
         }
@@ -125,9 +134,11 @@ bit_flags = {
     "sr_aerosol": {
         "L8": {
             "Fill": [0],
-            "Aerosol Retrieval - Valid": [1],
-            "Aerosol Retrieval - Interpolated": [2],
-            "Water": [3],
+            "Valid Aerosol Retrieval": [1],
+            "Water": [2],
+            "Cloud or Cirrus": [3],
+            "Cloud Shadow": [4],
+            "Interpolated Aerosol Retrieval": [5],
             "Low Aerosol": [6],
             "Medium Aerosol": [7],
             "High Aerosol": [6, 7]


### PR DESCRIPTION
@gschmidt-usgs and @raydittmeier 

Please review the changes in extract_bands.py and lookup_dict.py at your convenience and let me know of your thoughts. 
PS1: Changes in looup_dict.py are extracted from Table 7-6 and Table 7-2 in LaSRC product guide (https://landsat.usgs.gov/sites/default/files/documents/lasrc_product_guide.pdf)
PS2: Changes in extract_bands.py are made to resolve two issues: 1- When extracting a QA bit with zero occurrences in the image (e.g. "Fill"), the out_values parameters was returned empty and therefore ArcGIS Con statement was always true, and the tool was giving wrong result. (See the user comment in Issues tab); and 2- For the 2-bit attributes such as cloud confidence or cirrus confidence, the script did not make a distinction between 01 or 10 and 11 for bit extraction.    
 